### PR TITLE
Include missing instructions

### DIFF
--- a/site/en/install/gpu.md
+++ b/site/en/install/gpu.md
@@ -186,5 +186,6 @@ environmental variable. For example, if the CUDA Toolkit is installed to
 <pre class="devsite-click-to-copy">
 <code class="devsite-terminal tfo-terminal-windows">SET PATH=C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v10.0\bin;%PATH%</code>
 <code class="devsite-terminal tfo-terminal-windows">SET PATH=C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v10.0\extras\CUPTI\libx64;%PATH%</code>
+<code class="devsite-terminal tfo-terminal-windows">SET PATH=C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v10.0\include;%PATH%</code>
 <code class="devsite-terminal tfo-terminal-windows">SET PATH=C:\tools\cuda\bin;%PATH%</code>
 </pre>


### PR DESCRIPTION
Include instructions to add the 'C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v10.0\include' directory to the PATH variable on windows. This has been a cause of confusion and frustration for multiple windows users